### PR TITLE
refactor!: rename variables and outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Azure Container Instances Terraform module
+# Azure Container Instances (ACI) Terraform module
 
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://conventionalcommits.org)
 [![Equinor Terraform Baseline](https://img.shields.io/badge/Equinor%20Terraform%20Baseline-1.0.0-blueviolet)](https://github.com/equinor/terraform-baseline)
 
-Terraform module which creates Azure Container Instances resources.
+Terraform module which creates an ACI container group.
 
 ## WARNING
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -19,11 +19,11 @@ module "log_analytics" {
   location            = azurerm_resource_group.example.location
 }
 
-module "container" {
-  # source = "github.com/equinor/terraform-azurerm-container?ref=v0.0.0"
+module "aci" {
+  # source = "github.com/equinor/terraform-azurerm-aci?ref=v0.0.0"
   source = "../.."
 
-  instance_name               = "ci-${random_id.example.hex}"
+  container_group_name        = "ci-${random_id.example.hex}"
   resource_group_name         = azurerm_resource_group.example.name
   location                    = azurerm_resource_group.example.location
   log_analytics_workspace_id  = module.log_analytics.workspace_customer_id

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -46,11 +46,11 @@ resource "azurerm_storage_share" "example" {
   quota                = 5
 }
 
-module "container" {
-  # source = "github.com/equinor/terraform-azurerm-container?ref=v0.0.0"
+module "aci" {
+  # source = "github.com/equinor/terraform-azurerm-aci?ref=v0.0.0"
   source = "../.."
 
-  instance_name               = "ci-${random_id.example.hex}"
+  container_group_name        = "ci-${random_id.example.hex}"
   resource_group_name         = azurerm_resource_group.example.name
   location                    = azurerm_resource_group.example.location
   log_analytics_workspace_id  = module.log_analytics.workspace_customer_id

--- a/examples/private-ip-address/README.md
+++ b/examples/private-ip-address/README.md
@@ -1,3 +1,3 @@
 # Private IP address example
 
-Example Terraform configuration which shows how to create Azure Container Instances with a private IP address.
+Example Terraform configuration which shows how to create an ACI container group with a private IP address.

--- a/examples/private-ip-address/main.tf
+++ b/examples/private-ip-address/main.tf
@@ -41,11 +41,11 @@ module "network" {
   }
 }
 
-module "container" {
-  # source = "github.com/equinor/terraform-azurerm-container?ref=v0.0.0"
+module "aci" {
+  # source = "github.com/equinor/terraform-azurerm-aci?ref=v0.0.0"
   source = "../.."
 
-  instance_name               = "ci-${random_id.example.hex}"
+  container_group_name        = "ci-${random_id.example.hex}"
   resource_group_name         = azurerm_resource_group.example.name
   location                    = azurerm_resource_group.example.location
   log_analytics_workspace_id  = module.log_analytics.workspace_customer_id

--- a/examples/public-ip-address/README.md
+++ b/examples/public-ip-address/README.md
@@ -1,3 +1,3 @@
 # Public IP address example
 
-Example Terraform configuration which shows how to create Azure Container Instances with a public IP address.
+Example Terraform configuration which shows how to create an ACI container group with a public IP address.

--- a/examples/public-ip-address/main.tf
+++ b/examples/public-ip-address/main.tf
@@ -19,11 +19,11 @@ module "log_analytics" {
   location            = azurerm_resource_group.example.location
 }
 
-module "container" {
-  # source = "github.com/equinor/terraform-azurerm-container?ref=v0.0.0"
+module "aci" {
+  # source = "github.com/equinor/terraform-azurerm-aci?ref=v0.0.0"
   source = "../.."
 
-  instance_name               = "ci-${random_id.example.hex}"
+  container_group_name        = "ci-${random_id.example.hex}"
   resource_group_name         = azurerm_resource_group.example.name
   location                    = azurerm_resource_group.example.location
   log_analytics_workspace_id  = module.log_analytics.workspace_customer_id

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_container_group" "this" {
-  name                = var.instance_name
+  name                = var.container_group_name
   resource_group_name = var.resource_group_name
   location            = var.location
   os_type             = var.os_type

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "instance_id" {
+output "container_group_id" {
   description = "The ID of this Container Instance."
   value       = azurerm_container_group.this.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
-variable "instance_name" {
-  description = "The name of this Container Instance."
+variable "container_group_name" {
+  description = "The name of this Container Group."
   type        = string
 }
 
@@ -25,7 +25,7 @@ variable "log_analytics_workspace_key" {
 }
 
 variable "containers" {
-  description = "A list of containers to create for this Container Instance."
+  description = "A list of containers to create for this Container Group."
 
   type = list(object({
     name   = string
@@ -55,25 +55,25 @@ variable "containers" {
 }
 
 variable "os_type" {
-  description = "The OS type of this Container Instance."
+  description = "The OS type of this Container Group."
   type        = string
   default     = "Linux"
 }
 
 variable "restart_policy" {
-  description = "The restart policy of this Container Instance."
+  description = "The restart policy of this Container Group."
   type        = string
   default     = "Always"
 }
 
 variable "ip_address_type" {
-  description = "The IP address type of this Container Instance."
+  description = "The IP address type of this Container Group."
   type        = string
   default     = "None"
 }
 
 variable "dns_name_label" {
-  description = "A DNS name label for this Container Instance."
+  description = "A DNS name label for this Container Group."
   type        = string
   default     = null
 }
@@ -85,13 +85,13 @@ variable "dns_name_label_reuse_policy" {
 }
 
 variable "subnet_ids" {
-  description = "A list of subnet IDs to be assigned to this Container Instance."
+  description = "A list of subnet IDs to be assigned to this Container Group."
   type        = list(string)
   default     = null
 }
 
 variable "dns_config" {
-  description = "The DNS configuration of this Container Instance."
+  description = "The DNS configuration of this Container Group."
 
   type = object({
     nameservers = list(string)
@@ -101,7 +101,7 @@ variable "dns_config" {
 }
 
 variable "image_registry_credentials" {
-  description = "A list of image registry credentials to configure for this Container Instance."
+  description = "A list of image registry credentials to configure for this Container Group."
 
   type = list(object({
     server                    = string
@@ -114,7 +114,7 @@ variable "image_registry_credentials" {
 }
 
 variable "identity" {
-  description = "The identity or identities to configure for this Container Instance."
+  description = "The identity or identities to configure for this Container Group."
 
   type = object({
     type         = optional(string, "SystemAssigned")


### PR DESCRIPTION
Renamed module to `aci` and variables from `instance_*` to `container_group_*`, as microsoft usually refers to it as "ACI container group".

BREAKING CHANGE: variable `instance_name` renamed to
`container_group_name`, output `instance_id` renamed to
`container_group_id.`